### PR TITLE
Ranger 2.0.0 2.0

### DIFF
--- a/agents-audit/pom.xml
+++ b/agents-audit/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.ranger</groupId>
         <artifactId>ranger</artifactId>
-        <version>2.0.0-1.0</version>
+        <version>2.0.0-2.0-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
     <dependencies>

--- a/agents-common/pom.xml
+++ b/agents-common/pom.xml
@@ -39,7 +39,7 @@
     <parent>
         <groupId>org.apache.ranger</groupId>
         <artifactId>ranger</artifactId>
-        <version>2.0.0-1.0</version>
+        <version>2.0.0-2.0-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
     <dependencies>

--- a/agents-common/src/main/java/org/apache/ranger/plugin/policyengine/RangerAccessResourceImpl.java
+++ b/agents-common/src/main/java/org/apache/ranger/plugin/policyengine/RangerAccessResourceImpl.java
@@ -261,4 +261,8 @@ public class RangerAccessResourceImpl implements RangerMutableResource {
 
 		return sb;
 	}
+
+        protected String getStringifiedValue() { return stringifiedValue; }
+
+        protected void setStringifiedValue(String val) { this.stringifiedValue = val; }
 }

--- a/agents-common/src/main/java/org/apache/ranger/plugin/policyevaluator/RangerDefaultPolicyEvaluator.java
+++ b/agents-common/src/main/java/org/apache/ranger/plugin/policyevaluator/RangerDefaultPolicyEvaluator.java
@@ -147,9 +147,17 @@ public class RangerDefaultPolicyEvaluator extends RangerAbstractPolicyEvaluator 
 				denyExceptionEvaluators  = Collections.<RangerPolicyItemEvaluator>emptyList();
 			} else {
 				allowEvaluators          = createPolicyItemEvaluators(policy, serviceDef, options, RangerPolicyItemEvaluator.POLICY_ITEM_TYPE_ALLOW);
-				denyEvaluators           = createPolicyItemEvaluators(policy, serviceDef, options, RangerPolicyItemEvaluator.POLICY_ITEM_TYPE_DENY);
-				allowExceptionEvaluators = createPolicyItemEvaluators(policy, serviceDef, options, RangerPolicyItemEvaluator.POLICY_ITEM_TYPE_ALLOW_EXCEPTIONS);
-				denyExceptionEvaluators  = createPolicyItemEvaluators(policy, serviceDef, options, RangerPolicyItemEvaluator.POLICY_ITEM_TYPE_DENY_EXCEPTIONS);
+
+				if (ServiceDefUtil.getOption_enableDenyAndExceptionsInPolicies(serviceDef)) {
+					denyEvaluators           = createPolicyItemEvaluators(policy, serviceDef, options, RangerPolicyItemEvaluator.POLICY_ITEM_TYPE_DENY);
+					allowExceptionEvaluators = createPolicyItemEvaluators(policy, serviceDef, options, RangerPolicyItemEvaluator.POLICY_ITEM_TYPE_ALLOW_EXCEPTIONS);
+					denyExceptionEvaluators  = createPolicyItemEvaluators(policy, serviceDef, options, RangerPolicyItemEvaluator.POLICY_ITEM_TYPE_DENY_EXCEPTIONS);
+				} else {
+					denyEvaluators           = Collections.<RangerPolicyItemEvaluator>emptyList();
+					allowExceptionEvaluators = Collections.<RangerPolicyItemEvaluator>emptyList();
+					denyExceptionEvaluators  = Collections.<RangerPolicyItemEvaluator>emptyList();
+				}
+
 			}
 
 			dataMaskEvaluators  = createDataMaskPolicyItemEvaluators(policy, serviceDef, options, policy.getDataMaskPolicyItems());

--- a/agents-cred/pom.xml
+++ b/agents-cred/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.ranger</groupId>
         <artifactId>ranger</artifactId>
-        <version>2.0.0-1.0</version>
+        <version>2.0.0-2.0-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
     <dependencies>

--- a/agents-installer/pom.xml
+++ b/agents-installer/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.ranger</groupId>
         <artifactId>ranger</artifactId>
-        <version>2.0.0-1.0</version>
+        <version>2.0.0-2.0-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
     <dependencies>

--- a/credentialbuilder/pom.xml
+++ b/credentialbuilder/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.ranger</groupId>
         <artifactId>ranger</artifactId>
-        <version>2.0.0-1.0</version>
+        <version>2.0.0-2.0-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
     <dependencies>

--- a/distro/pom.xml
+++ b/distro/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.ranger</groupId>
         <artifactId>ranger</artifactId>
-        <version>2.0.0-1.0</version>
+        <version>2.0.0-2.0-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/embeddedwebserver/pom.xml
+++ b/embeddedwebserver/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.ranger</groupId>
         <artifactId>ranger</artifactId>
-        <version>2.0.0-1.0</version>
+        <version>2.0.0-2.0-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
     <dependencies>

--- a/hbase-agent/pom.xml
+++ b/hbase-agent/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.apache.ranger</groupId>
         <artifactId>ranger</artifactId>
-        <version>2.0.0-1.0</version>
+        <version>2.0.0-2.0-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
     <dependencies>

--- a/hdfs-agent/pom.xml
+++ b/hdfs-agent/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.ranger</groupId>
         <artifactId>ranger</artifactId>
-        <version>2.0.0-1.0</version>
+        <version>2.0.0-2.0-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
     <dependencies>

--- a/hdfs-agent/src/main/java/org/apache/ranger/authorization/hadoop/RangerHdfsAuthorizer.java
+++ b/hdfs-agent/src/main/java/org/apache/ranger/authorization/hadoop/RangerHdfsAuthorizer.java
@@ -30,6 +30,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.Stack;
 
@@ -813,6 +814,19 @@ class RangerHdfsResource extends RangerAccessResourceImpl {
 	public RangerHdfsResource(String path, String owner) {
 		super.setValue(RangerHdfsAuthorizer.KEY_RESOURCE_PATH, path);
 		super.setOwnerUser(owner);
+	}
+
+	@Override
+	public String getAsString() {
+		String ret = super.getStringifiedValue();
+
+		if (ret == null) {
+			ret = Objects.toString(super.getValue(RangerHdfsAuthorizer.KEY_RESOURCE_PATH));
+
+			super.setStringifiedValue(ret);
+		}
+
+		return ret;
 	}
 }
 

--- a/hive-agent/pom.xml
+++ b/hive-agent/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.ranger</groupId>
         <artifactId>ranger</artifactId>
-        <version>2.0.0-1.0</version>
+        <version>2.0.0-2.0-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
     <dependencies>

--- a/jisql/pom.xml
+++ b/jisql/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.ranger</groupId>
         <artifactId>ranger</artifactId>
-        <version>2.0.0-1.0</version>
+        <version>2.0.0-2.0-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
     <dependencies>

--- a/kms/pom.xml
+++ b/kms/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.ranger</groupId>
         <artifactId>ranger</artifactId>
-        <version>2.0.0-1.0</version>
+        <version>2.0.0-2.0-SNAPSHOT</version>
     </parent>
     <dependencies>
         <dependency>

--- a/knox-agent/pom.xml
+++ b/knox-agent/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.ranger</groupId>
         <artifactId>ranger</artifactId>
-        <version>2.0.0-1.0</version>
+        <version>2.0.0-2.0-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
     <dependencies>

--- a/plugin-atlas/pom.xml
+++ b/plugin-atlas/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.ranger</groupId>
         <artifactId>ranger</artifactId>
-        <version>2.0.0-1.0</version>
+        <version>2.0.0-2.0-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
     <dependencies>

--- a/plugin-elasticsearch/pom.xml
+++ b/plugin-elasticsearch/pom.xml
@@ -29,7 +29,7 @@
 	<parent>
 		<groupId>org.apache.ranger</groupId>
 		<artifactId>ranger</artifactId>
-		<version>2.0.0-1.0</version>
+		<version>2.0.0-2.0-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
 	<dependencies>

--- a/plugin-kafka/pom.xml
+++ b/plugin-kafka/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.apache.ranger</groupId>
         <artifactId>ranger</artifactId>
-        <version>2.0.0-1.0</version>
+        <version>2.0.0-2.0-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
     <dependencies>

--- a/plugin-kms/pom.xml
+++ b/plugin-kms/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.ranger</groupId>
         <artifactId>ranger</artifactId>
-        <version>2.0.0-1.0</version>
+        <version>2.0.0-2.0-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
     <dependencies>

--- a/plugin-kylin/pom.xml
+++ b/plugin-kylin/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.apache.ranger</groupId>
         <artifactId>ranger</artifactId>
-        <version>2.0.0-1.0</version>
+        <version>2.0.0-2.0-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
     <dependencies>

--- a/plugin-nifi-registry/pom.xml
+++ b/plugin-nifi-registry/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <artifactId>ranger</artifactId>
         <groupId>org.apache.ranger</groupId>
-        <version>2.0.0-1.0</version>
+        <version>2.0.0-2.0-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
     <dependencies>

--- a/plugin-nifi/pom.xml
+++ b/plugin-nifi/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.ranger</groupId>
         <artifactId>ranger</artifactId>
-        <version>2.0.0-1.0</version>
+        <version>2.0.0-2.0-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
     <dependencies>

--- a/plugin-ozone/pom.xml
+++ b/plugin-ozone/pom.xml
@@ -30,7 +30,7 @@ limitations under the License.
     <parent>
         <artifactId>ranger</artifactId>
         <groupId>org.apache.ranger</groupId>
-        <version>2.0.0-1.0</version>
+        <version>2.0.0-2.0-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
     <dependencies>

--- a/plugin-presto/pom.xml
+++ b/plugin-presto/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.apache.ranger</groupId>
         <artifactId>ranger</artifactId>
-        <version>2.0.0-1.0</version>
+        <version>2.0.0-2.0-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
     <dependencies>

--- a/plugin-solr/pom.xml
+++ b/plugin-solr/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.ranger</groupId>
         <artifactId>ranger</artifactId>
-        <version>2.0.0-1.0</version>
+        <version>2.0.0-2.0-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
     <dependencies>

--- a/plugin-sqoop/pom.xml
+++ b/plugin-sqoop/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.apache.ranger</groupId>
         <artifactId>ranger</artifactId>
-        <version>2.0.0-1.0</version>
+        <version>2.0.0-2.0-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
     <dependencies>

--- a/plugin-yarn/pom.xml
+++ b/plugin-yarn/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.ranger</groupId>
         <artifactId>ranger</artifactId>
-        <version>2.0.0-1.0</version>
+        <version>2.0.0-2.0-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -117,7 +117,7 @@
         <googlecode.log4jdbc.version>1.2</googlecode.log4jdbc.version>
         <gson.version>2.2.4</gson.version>
         <guice.version>4.0</guice.version>
-        <hadoop.version>3.1.1-0.0</hadoop.version>
+        <hadoop.version>3.1.4-1.0-SNAPSHOT</hadoop.version>
 	<ozone.version>0.4.0-alpha</ozone.version>
         <hamcrest.all.version>1.3</hamcrest.all.version>
         <hbase.version>2.1.10-1.0</hbase.version>

--- a/pom.xml
+++ b/pom.xml
@@ -120,7 +120,7 @@
         <hadoop.version>3.1.4-1.0-SNAPSHOT</hadoop.version>
 	<ozone.version>0.4.0-alpha</ozone.version>
         <hamcrest.all.version>1.3</hamcrest.all.version>
-        <hbase.version>2.1.10-1.0</hbase.version>
+        <hbase.version>2.1.10-2.0-SNAPSHOT</hbase.version>
         <hive.version>3.1.3-1.0</hive.version>
         <hbase-shaded-protobuf>2.0.0</hbase-shaded-protobuf>
         <hbase-shaded-netty>2.0.0</hbase-shaded-netty>

--- a/pom.xml
+++ b/pom.xml
@@ -121,7 +121,7 @@
 	<ozone.version>0.4.0-alpha</ozone.version>
         <hamcrest.all.version>1.3</hamcrest.all.version>
         <hbase.version>2.1.10-2.0-SNAPSHOT</hbase.version>
-        <hive.version>3.1.3-1.0</hive.version>
+        <hive.version>3.1.3-2.0-SNAPSHOT</hive.version>
         <hbase-shaded-protobuf>2.0.0</hbase-shaded-protobuf>
         <hbase-shaded-netty>2.0.0</hbase-shaded-netty>
         <hbase-shaded-miscellaneous>2.0.0</hbase-shaded-miscellaneous>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     </parent>
     <groupId>org.apache.ranger</groupId>
     <artifactId>ranger</artifactId>
-    <version>2.0.0-1.0</version>
+    <version>2.0.0-2.0-SNAPSHOT</version>
     <description>Security for Enforcing Enterprise Policies</description>
     <packaging>pom</packaging>
     <name>ranger</name>

--- a/ranger-atlas-plugin-shim/pom.xml
+++ b/ranger-atlas-plugin-shim/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.ranger</groupId>
         <artifactId>ranger</artifactId>
-        <version>2.0.0-1.0</version>
+        <version>2.0.0-2.0-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
     <dependencies>

--- a/ranger-elasticsearch-plugin-shim/pom.xml
+++ b/ranger-elasticsearch-plugin-shim/pom.xml
@@ -29,7 +29,7 @@
 	<parent>
 		<groupId>org.apache.ranger</groupId>
 		<artifactId>ranger</artifactId>
-		<version>2.0.0-1.0</version>
+		<version>2.0.0-2.0-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
 	<dependencies>

--- a/ranger-examples/conditions-enrichers/pom.xml
+++ b/ranger-examples/conditions-enrichers/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>ranger-examples</artifactId>
         <groupId>org.apache.ranger</groupId>
-        <version>2.0.0-1.0</version>
+        <version>2.0.0-2.0-SNAPSHOT</version>
     </parent>
     <dependencies>
         <dependency>

--- a/ranger-examples/distro/pom.xml
+++ b/ranger-examples/distro/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.ranger</groupId>
         <artifactId>ranger-examples</artifactId>
-        <version>2.0.0-1.0</version>
+        <version>2.0.0-2.0-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/ranger-examples/plugin-sampleapp/pom.xml
+++ b/ranger-examples/plugin-sampleapp/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <artifactId>ranger-examples</artifactId>
         <groupId>org.apache.ranger</groupId>
-        <version>2.0.0-1.0</version>
+        <version>2.0.0-2.0-SNAPSHOT</version>
     </parent>
     <dependencies>
         <dependency>

--- a/ranger-examples/pom.xml
+++ b/ranger-examples/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>ranger</artifactId>
         <groupId>org.apache.ranger</groupId>
-        <version>2.0.0-1.0</version>
+        <version>2.0.0-2.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>ranger-examples</artifactId>

--- a/ranger-examples/sampleapp/pom.xml
+++ b/ranger-examples/sampleapp/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <artifactId>ranger-examples</artifactId>
         <groupId>org.apache.ranger</groupId>
-        <version>2.0.0-1.0</version>
+        <version>2.0.0-2.0-SNAPSHOT</version>
     </parent>
     <dependencies>
         <dependency>

--- a/ranger-hbase-plugin-shim/pom.xml
+++ b/ranger-hbase-plugin-shim/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.ranger</groupId>
         <artifactId>ranger</artifactId>
-        <version>2.0.0-1.0</version>
+        <version>2.0.0-2.0-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
     <dependencies>

--- a/ranger-hdfs-plugin-shim/pom.xml
+++ b/ranger-hdfs-plugin-shim/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.ranger</groupId>
         <artifactId>ranger</artifactId>
-        <version>2.0.0-1.0</version>
+        <version>2.0.0-2.0-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
     <dependencies>

--- a/ranger-hive-plugin-shim/pom.xml
+++ b/ranger-hive-plugin-shim/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.ranger</groupId>
         <artifactId>ranger</artifactId>
-        <version>2.0.0-1.0</version>
+        <version>2.0.0-2.0-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
     <dependencies>

--- a/ranger-kafka-plugin-shim/pom.xml
+++ b/ranger-kafka-plugin-shim/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.apache.ranger</groupId>
         <artifactId>ranger</artifactId>
-        <version>2.0.0-1.0</version>
+        <version>2.0.0-2.0-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
     <dependencies>

--- a/ranger-kms-plugin-shim/pom.xml
+++ b/ranger-kms-plugin-shim/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.ranger</groupId>
         <artifactId>ranger</artifactId>
-        <version>2.0.0-1.0</version>
+        <version>2.0.0-2.0-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
     <dependencies>

--- a/ranger-knox-plugin-shim/pom.xml
+++ b/ranger-knox-plugin-shim/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.ranger</groupId>
         <artifactId>ranger</artifactId>
-        <version>2.0.0-1.0</version>
+        <version>2.0.0-2.0-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
     <dependencies>

--- a/ranger-kylin-plugin-shim/pom.xml
+++ b/ranger-kylin-plugin-shim/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.apache.ranger</groupId>
         <artifactId>ranger</artifactId>
-        <version>2.0.0-1.0</version>
+        <version>2.0.0-2.0-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
     <dependencies>

--- a/ranger-ozone-plugin-shim/pom.xml
+++ b/ranger-ozone-plugin-shim/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <artifactId>ranger</artifactId>
         <groupId>org.apache.ranger</groupId>
-        <version>2.0.0-1.0</version>
+        <version>2.0.0-2.0-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
     <dependencies>

--- a/ranger-plugin-classloader/pom.xml
+++ b/ranger-plugin-classloader/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.apache.ranger</groupId>
         <artifactId>ranger</artifactId>
-        <version>2.0.0-1.0</version>
+        <version>2.0.0-2.0-SNAPSHOT</version>
     </parent>
     <dependencies>
         <dependency>

--- a/ranger-presto-plugin-shim/pom.xml
+++ b/ranger-presto-plugin-shim/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.ranger</groupId>
         <artifactId>ranger</artifactId>
-        <version>2.0.0-1.0</version>
+        <version>2.0.0-2.0-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
     <dependencies>

--- a/ranger-solr-plugin-shim/pom.xml
+++ b/ranger-solr-plugin-shim/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.ranger</groupId>
         <artifactId>ranger</artifactId>
-        <version>2.0.0-1.0</version>
+        <version>2.0.0-2.0-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
     <dependencies>

--- a/ranger-sqoop-plugin-shim/pom.xml
+++ b/ranger-sqoop-plugin-shim/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.apache.ranger</groupId>
         <artifactId>ranger</artifactId>
-        <version>2.0.0-1.0</version>
+        <version>2.0.0-2.0-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
     <dependencies>

--- a/ranger-storm-plugin-shim/pom.xml
+++ b/ranger-storm-plugin-shim/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.ranger</groupId>
         <artifactId>ranger</artifactId>
-        <version>2.0.0-1.0</version>
+        <version>2.0.0-2.0-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
     <dependencies>

--- a/ranger-tools/pom.xml
+++ b/ranger-tools/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>ranger</artifactId>
         <groupId>org.apache.ranger</groupId>
-        <version>2.0.0-1.0</version>
+        <version>2.0.0-2.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>ranger-tools</artifactId>

--- a/ranger-util/pom.xml
+++ b/ranger-util/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.ranger</groupId>
         <artifactId>ranger</artifactId>
-        <version>2.0.0-1.0</version>
+        <version>2.0.0-2.0-SNAPSHOT</version>
     </parent>
     <artifactId>ranger-util</artifactId>
     <name>Ranger Util</name>

--- a/ranger-yarn-plugin-shim/pom.xml
+++ b/ranger-yarn-plugin-shim/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.ranger</groupId>
         <artifactId>ranger</artifactId>
-        <version>2.0.0-1.0</version>
+        <version>2.0.0-2.0-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
     <dependencies>

--- a/security-admin/pom.xml
+++ b/security-admin/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.ranger</groupId>
         <artifactId>ranger</artifactId>
-        <version>2.0.0-1.0</version>
+        <version>2.0.0-2.0-SNAPSHOT</version>
     </parent>
     <properties>
         <skipJSTests>false</skipJSTests>

--- a/storm-agent/pom.xml
+++ b/storm-agent/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.ranger</groupId>
         <artifactId>ranger</artifactId>
-        <version>2.0.0-1.0</version>
+        <version>2.0.0-2.0-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
     <dependencies>

--- a/tagsync/pom.xml
+++ b/tagsync/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <artifactId>ranger</artifactId>
         <groupId>org.apache.ranger</groupId>
-        <version>2.0.0-1.0</version>
+        <version>2.0.0-2.0-SNAPSHOT</version>
     </parent>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/ugsync/ldapconfigchecktool/ldapconfigcheck/pom.xml
+++ b/ugsync/ldapconfigchecktool/ldapconfigcheck/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.ranger</groupId>
         <artifactId>ranger</artifactId>
-        <version>2.0.0-1.0</version>
+        <version>2.0.0-2.0-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
     <artifactId>ldapconfigcheck</artifactId>

--- a/ugsync/pom.xml
+++ b/ugsync/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.ranger</groupId>
         <artifactId>ranger</artifactId>
-        <version>2.0.0-1.0</version>
+        <version>2.0.0-2.0-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
     <artifactId>unixusersync</artifactId>

--- a/unixauthclient/pom.xml
+++ b/unixauthclient/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.ranger</groupId>
         <artifactId>ranger</artifactId>
-        <version>2.0.0-1.0</version>
+        <version>2.0.0-2.0-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
     <artifactId>unixauthclient</artifactId>

--- a/unixauthnative/pom.xml
+++ b/unixauthnative/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.ranger</groupId>
         <artifactId>ranger</artifactId>
-        <version>2.0.0-1.0</version>
+        <version>2.0.0-2.0-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
     <artifactId>credValidator</artifactId>

--- a/unixauthpam/pom.xml
+++ b/unixauthpam/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.ranger</groupId>
         <artifactId>ranger</artifactId>
-        <version>2.0.0-1.0</version>
+        <version>2.0.0-2.0-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
     <artifactId>pamCredValidator</artifactId>

--- a/unixauthservice/pom.xml
+++ b/unixauthservice/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.ranger</groupId>
         <artifactId>ranger</artifactId>
-        <version>2.0.0-1.0</version>
+        <version>2.0.0-2.0-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
     <artifactId>unixauthservice</artifactId>


### PR DESCRIPTION
Relates to https://github.com/TOSIT-IO/TDP/pull/90

Included in the PR:

Bump 3 TDP dependencies (hadoop, hbase and hive) to their TDP 1.1 versions.

Backports RANGER-3378, RANGER-3377. Theses two fixes are included in upstream 2.0.1-SNASPHOT that will likely never be released. The choice is ours to include them or not.

Please note that the PR is created over the newly created ranger-2.0.0-TDP (I should have done this on every project, makes everything easier to read)