### PR TITLE
Branch 2.4.0 hive 4 basic

### DIFF
--- a/hbase-agent/pom.xml
+++ b/hbase-agent/pom.xml
@@ -24,7 +24,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <hbase.jetty.version>9.3.27.v20190418</hbase.jetty.version>
-        <hadoop.version>3.1.1</hadoop.version>
+        <hadoop.version>3.3.6-1.0</hadoop.version>
     </properties>
     <parent>
         <groupId>org.apache.ranger</groupId>

--- a/hive-agent/pom.xml
+++ b/hive-agent/pom.xml
@@ -31,7 +31,24 @@
         <version>2.4.0-1.0-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
+    <repositories>
+        <repository>
+            <id>central</id>
+            <name>maven central</name>
+            <url>https://repo1.maven.org/maven2/</url>
+        </repository>
+    </repositories>
     <dependencies>
+        <dependency>
+            <groupId>javax.validation</groupId>
+            <artifactId>validation-api</artifactId>
+            <version>2.0.1.Final</version>
+        </dependency>
+        <dependency>
+            <groupId>commons-collections</groupId>
+            <artifactId>commons-collections</artifactId>
+            <version>${commons.collections.version}</version>
+        </dependency>
         <dependency>
             <groupId>commons-lang</groupId>
             <artifactId>commons-lang</artifactId>

--- a/hive-agent/pom.xml
+++ b/hive-agent/pom.xml
@@ -23,7 +23,7 @@
     <packaging>jar</packaging>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <hadoop.version>3.1.1</hadoop.version>
+        <hadoop.version>3.3.6-1.0</hadoop.version>
     </properties>
     <parent>
         <groupId>org.apache.ranger</groupId>

--- a/hive-agent/src/main/java/org/apache/ranger/authorization/hive/authorizer/RangerHiveAuthorizer.java
+++ b/hive-agent/src/main/java/org/apache/ranger/authorization/hive/authorizer/RangerHiveAuthorizer.java
@@ -1732,9 +1732,9 @@ public class RangerHiveAuthorizer extends RangerHiveAuthorizerBase {
 				case ALTERDATABASE:
 				case ALTERDATABASE_LOCATION:
 				case ALTERDATABASE_OWNER:
-				case ALTERINDEX_PROPS:
-				case ALTERINDEX_REBUILD:
-				case ALTERPARTITION_BUCKETNUM:
+				// case ALTERINDEX_PROPS:
+				// case ALTERINDEX_REBUILD:
+				// case ALTERPARTITION_BUCKETNUM:
 				case ALTERPARTITION_FILEFORMAT:
 				case ALTERPARTITION_LOCATION:
 				case ALTERPARTITION_MERGEFILES:
@@ -1772,13 +1772,13 @@ public class RangerHiveAuthorizer extends RangerHiveAuthorizerBase {
 				case ALTERVIEW_PROPERTIES:
 				case ALTERVIEW_RENAME:
 				case ALTER_MATERIALIZED_VIEW_REWRITE:
-				case DROPVIEW_PROPERTIES:
+				// case DROPVIEW_PROPERTIES:
 				case MSCK:
 					accessType = HiveAccessType.ALTER;
 				break;
 
 				case DROPFUNCTION:
-				case DROPINDEX:
+				// case DROPINDEX:
 				case DROPTABLE:
 				case DROPVIEW:
 				case DROP_MATERIALIZED_VIEW:
@@ -1786,9 +1786,9 @@ public class RangerHiveAuthorizer extends RangerHiveAuthorizerBase {
 					accessType = HiveAccessType.DROP;
 				break;
 
-				case CREATEINDEX:
-					accessType = HiveAccessType.INDEX;
-				break;
+				// case CREATEINDEX:
+					// accessType = HiveAccessType.INDEX;
+				// break;
 
 				case IMPORT:
 					/*
@@ -1822,7 +1822,7 @@ public class RangerHiveAuthorizer extends RangerHiveAuthorizerBase {
 				case QUERY:
 				case SHOW_TABLESTATUS:
 				case SHOW_CREATETABLE:
-				case SHOWINDEXES:
+				// case SHOWINDEXES:
 				case SHOWPARTITIONS:
 				case SHOW_TBLPROPERTIES:
 				case ANALYZE_TABLE:
@@ -1969,7 +1969,7 @@ public class RangerHiveAuthorizer extends RangerHiveAuthorizerBase {
 			case ALTERTABLE_PROTECTMODE:
 			case ALTERTABLE_FILEFORMAT:
 			case ALTERTABLE_LOCATION:
-			case ALTERINDEX_PROPS:
+			// case ALTERINDEX_PROPS:
 			case ALTERTABLE_MERGEFILES:
 			case ALTERTABLE_SKEWED:
 			case ALTERTABLE_COMPACT:
@@ -2009,7 +2009,7 @@ public class RangerHiveAuthorizer extends RangerHiveAuthorizerBase {
 			case SHOW_CREATETABLE:
 			case SHOWFUNCTIONS:
 			case SHOWVIEWS:
-			case SHOWINDEXES:
+			// case SHOWINDEXES:
 			case SHOWPARTITIONS:
 			case SHOWLOCKS:
 			case SHOWCONF:
@@ -2018,11 +2018,11 @@ public class RangerHiveAuthorizer extends RangerHiveAuthorizerBase {
 			case CREATEVIEW:
 			case DROPVIEW:
 			case CREATE_MATERIALIZED_VIEW:
-			case CREATEINDEX:
-			case DROPINDEX:
-			case ALTERINDEX_REBUILD:
+			// case CREATEINDEX:
+			// case DROPINDEX:
+			// case ALTERINDEX_REBUILD:
 			case ALTERVIEW_PROPERTIES:
-			case DROPVIEW_PROPERTIES:
+			// case DROPVIEW_PROPERTIES:
 			case DROP_MATERIALIZED_VIEW:
 			case ALTER_MATERIALIZED_VIEW_REWRITE:
 			case LOCKTABLE:

--- a/hive-agent/src/main/java/org/apache/ranger/authorization/hive/authorizer/RangerHiveAuthorizerBase.java
+++ b/hive-agent/src/main/java/org/apache/ranger/authorization/hive/authorizer/RangerHiveAuthorizerBase.java
@@ -100,14 +100,14 @@ public abstract class RangerHiveAuthorizerBase extends AbstractHiveAuthorizer {
 		// from SQLStdHiveAccessController.applyAuthorizationConfigPolicy()
 		if (mSessionContext != null && mSessionContext.getClientType() == CLIENT_TYPE.HIVESERVER2) {
 			// Configure PREEXECHOOKS with DisallowTransformHook to disallow transform queries
-			String hooks = hiveConf.getVar(ConfVars.PREEXECHOOKS).trim();
+			String hooks = hiveConf.getVar(ConfVars.PRE_EXEC_HOOKS).trim();
 			if (hooks.isEmpty()) {
 				hooks = DisallowTransformHook.class.getName();
 			} else {
 				hooks = hooks + "," + DisallowTransformHook.class.getName();
 			}
 
-			hiveConf.setVar(ConfVars.PREEXECHOOKS, hooks);
+			hiveConf.setVar(ConfVars.PRE_EXEC_HOOKS, hooks);
 
 			SettableConfigUpdater.setHiveConfWhiteList(hiveConf);
 		}

--- a/hive-agent/src/test/java/org/apache/ranger/services/hive/HIVERangerAuthorizerTest.java
+++ b/hive-agent/src/test/java/org/apache/ranger/services/hive/HIVERangerAuthorizerTest.java
@@ -75,7 +75,7 @@ public class HIVERangerAuthorizerTest {
 
         // Warehouse
         File warehouseDir = new File("./target/hdfs/warehouse").getAbsoluteFile();
-        conf.set(HiveConf.ConfVars.METASTOREWAREHOUSE.varname, warehouseDir.getPath());
+        conf.set(HiveConf.ConfVars.METASTORE_WAREHOUSE.varname, warehouseDir.getPath());
 
         // Scratchdir
         File scratchDir = new File("./target/hdfs/scratchdir").getAbsoluteFile();
@@ -87,7 +87,7 @@ public class HIVERangerAuthorizerTest {
 
         // Create a temporary directory for the Hive metastore
         File metastoreDir = new File("./metastore_db/").getAbsoluteFile();
-        conf.set(HiveConf.ConfVars.METASTORECONNECTURLKEY.varname,
+        conf.set(HiveConf.ConfVars.METASTORE_CONNECT_URL_KEY.varname,
                  String.format("jdbc:derby:;databaseName=%s;create=true",  metastoreDir.getPath()));
 
         conf.set(HiveConf.ConfVars.METASTORE_AUTO_CREATE_ALL.varname, "true");

--- a/plugin-schema-registry/pom.xml
+++ b/plugin-schema-registry/pom.xml
@@ -32,7 +32,7 @@
     </parent>
 
     <properties>
-        <hadoop.version>3.1.1</hadoop.version>
+        <hadoop.version>3.3.6-1.0</hadoop.version>
         <jersey.version>2.22.1</jersey.version>
         <schema.registry.version>0.9.1</schema.registry.version>
         <jettison.version>1.1</jettison.version>

--- a/pom.xml
+++ b/pom.xml
@@ -125,7 +125,7 @@
         <ozone.version>1.0.0</ozone.version>
         <hamcrest.version>2.2</hamcrest.version>
         <hbase.version>2.4.17-1.0</hbase.version>
-        <hive.version>3.1.3-3.0</hive.version>
+        <hive.version>4.0.0-0.0</hive.version>
         <hive.storage-api.version>2.7.2</hive.storage-api.version>
         <orc.version>1.5.8</orc.version>
         <hbase-shaded-protobuf>3.5.1</hbase-shaded-protobuf>


### PR DESCRIPTION
This PR patches Ranger 2.4.0 to compile with Hive 4.0.0. Operations in `hive-agent/src/main/java/org/apache/ranger/authorization/hive/authorizer/RangerHiveAuthorizer.java` have been commented out since maven does not find them in the Hive 4 jars, however, their equivalent still need to be found as well as additional operations that only exist in Hive 4.